### PR TITLE
Switch to Internet Archive link for an outdated link

### DIFF
--- a/minizinc/bin_packing2.mzn
+++ b/minizinc/bin_packing2.mzn
@@ -2,7 +2,7 @@
 % Global constraint bin_packing in MiniZinc.
 % 
 % From Global Constraint Catalogue
-% http://www.emn.fr/x-info/sdemasse/gccat/Cbin_packing.html
+% https://web.archive.org/web/20090801131346/http://www.emn.fr/x-info/sdemasse/gccat/Cbin_packing.html
 % """
 % Given several items of the collection ITEMS (each of them having a specific 
 % weight), and different bins of a fixed capacity, assign each item to a bin 


### PR DESCRIPTION
Use the latest Internet Archive version for bin_packing page in Global Constraint Catalog